### PR TITLE
fix up the namespace in testing job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -14,12 +14,12 @@
         - "trigger-build":
             vars:
               cluster: "paas.psi.redhat.com"
-              namespace: "thoth-core-test"
+              namespace: "thoth-test-core"
               buildConfigName: "user-api"
         - "trigger-build":
             vars:
-              cluster: "pass.psi.redhat.com"
-              namespace: "thoth-core-test"
+              cluster: "paas.psi.redhat.com"
+              namespace: "thoth-test-core"
               buildConfigName: "management-api"
 
     kebechet-auto-gate:


### PR DESCRIPTION
Change namespace typo `thoth-core-test` to `thoth-test-core` and cluster typo `pass.psi.redhat.com` to `paas.psi.redhat.com`.