### PR TITLE
Do another trigger build test with result-api

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -15,12 +15,12 @@
             vars:
               cluster: "paas.psi.redhat.com"
               namespace: "thoth-test-core"
-              buildConfigName: "user-api"
-        - "trigger-build":
-            vars:
-              cluster: "paas.psi.redhat.com"
-              namespace: "thoth-test-core"
-              buildConfigName: "management-api"
+              buildConfigName: "result-api"
+              # - "trigger-build":
+              #     vars:
+              #       cluster: "paas.psi.redhat.com"
+              #       namespace: "thoth-test-core"
+              #       buildConfigName: "management-api"
 
     kebechet-auto-gate:
       jobs:


### PR DESCRIPTION
At this moment, `result-api` contains the generic trigger with its `buildconfig` file, do another test with `result-api`.